### PR TITLE
feat: [#14] add top movie selection in profile page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@mui/icons-material": "^7.3.5",
         "@mui/material": "^7.3.4",
         "@react-oauth/google": "^0.12.2",
         "next": "15.5.4",
@@ -273,6 +274,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -316,6 +318,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
       "integrity": "sha512-qEEJt42DuToa3gurlH4Qqc1kVpNq8wO8cJtDzU46TjlzWjDlsVyevtYCRijVq3SrHsROS+gVQ8Fnea108GnKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -1045,32 +1048,58 @@
       }
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.4.tgz",
-      "integrity": "sha512-BIktMapG3r4iXwIhYNpvk97ZfYWTreBBQTWjQKbNbzI64+ULHfYavQEX2w99aSWHS58DvXESWIgbD9adKcUOBw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-7.3.5.tgz",
+      "integrity": "sha512-kOLwlcDPnVz2QMhiBv0OQ8le8hTCqKM9cRXlfVPL91l3RGeOsxrIhNRsUt3Xb8wb+pTVUolW+JXKym93vRKxCw==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       }
     },
+    "node_modules/@mui/icons-material": {
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-7.3.5.tgz",
+      "integrity": "sha512-LciL1GLMZ+VlzyHAALSVAR22t8IST4LCXmljcUSx2NOutgO2XnxdIp8ilFbeNf9wpo0iUFbAuoQcB7h+HHIf3A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^7.3.5",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@mui/material": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.4.tgz",
-      "integrity": "sha512-gEQL9pbJZZHT7lYJBKQCS723v1MGys2IFc94COXbUIyCTWa+qC77a7hUax4Yjd5ggEm35dk4AyYABpKKWC4MLw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-7.3.5.tgz",
+      "integrity": "sha512-8VVxFmp1GIm9PpmnQoCoYo0UWHoOrdA57tDL62vkpzEgvb/d71Wsbv4FRg7r1Gyx7PuSo0tflH34cdl/NvfHNQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@mui/core-downloads-tracker": "^7.3.4",
-        "@mui/system": "^7.3.3",
-        "@mui/types": "^7.4.7",
-        "@mui/utils": "^7.3.3",
+        "@mui/core-downloads-tracker": "^7.3.5",
+        "@mui/system": "^7.3.5",
+        "@mui/types": "^7.4.8",
+        "@mui/utils": "^7.3.5",
         "@popperjs/core": "^2.11.8",
         "@types/react-transition-group": "^4.4.12",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1",
-        "react-is": "^19.1.1",
+        "react-is": "^19.2.0",
         "react-transition-group": "^4.4.5"
       },
       "engines": {
@@ -1083,7 +1112,7 @@
       "peerDependencies": {
         "@emotion/react": "^11.5.0",
         "@emotion/styled": "^11.3.0",
-        "@mui/material-pigment-css": "^7.3.3",
+        "@mui/material-pigment-css": "^7.3.5",
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -1110,13 +1139,13 @@
       "license": "MIT"
     },
     "node_modules/@mui/private-theming": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.3.tgz",
-      "integrity": "sha512-OJM+9nj5JIyPUvsZ5ZjaeC9PfktmK+W5YaVLToLR8L0lB/DGmv1gcKE43ssNLSvpoW71Hct0necfade6+kW3zQ==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-7.3.5.tgz",
+      "integrity": "sha512-cTx584W2qrLonwhZLbEN7P5pAUu0nZblg8cLBlTrZQ4sIiw8Fbvg7GvuphQaSHxPxrCpa7FDwJKtXdbl2TSmrA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@mui/utils": "^7.3.3",
+        "@mui/utils": "^7.3.5",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -1137,9 +1166,9 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.3.tgz",
-      "integrity": "sha512-CmFxvRJIBCEaWdilhXMw/5wFJ1+FT9f3xt+m2pPXhHPeVIbBg9MnMvNSJjdALvnQJMPw8jLhrUtXmN7QAZV2fw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-7.3.5.tgz",
+      "integrity": "sha512-zbsZ0uYYPndFCCPp2+V3RLcAN6+fv4C8pdwRx6OS3BwDkRCN8WBehqks7hWyF3vj1kdQLIWrpdv/5Y0jHRxYXQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
@@ -1171,16 +1200,16 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.3.tgz",
-      "integrity": "sha512-Lqq3emZr5IzRLKaHPuMaLBDVaGvxoh6z7HMWd1RPKawBM5uMRaQ4ImsmmgXWtwJdfZux5eugfDhXJUo2mliS8Q==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-7.3.5.tgz",
+      "integrity": "sha512-yPaf5+gY3v80HNkJcPi6WT+r9ebeM4eJzrREXPxMt7pNTV/1eahyODO4fbH3Qvd8irNxDFYn5RQ3idHW55rA6g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@mui/private-theming": "^7.3.3",
-        "@mui/styled-engine": "^7.3.3",
-        "@mui/types": "^7.4.7",
-        "@mui/utils": "^7.3.3",
+        "@mui/private-theming": "^7.3.5",
+        "@mui/styled-engine": "^7.3.5",
+        "@mui/types": "^7.4.8",
+        "@mui/utils": "^7.3.5",
         "clsx": "^2.1.1",
         "csstype": "^3.1.3",
         "prop-types": "^15.8.1"
@@ -1211,9 +1240,9 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.7.tgz",
-      "integrity": "sha512-8vVje9rdEr1rY8oIkYgP+Su5Kwl6ik7O3jQ0wl78JGSmiZhRHV+vkjooGdKD8pbtZbutXFVTWQYshu2b3sG9zw==",
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.4.8.tgz",
+      "integrity": "sha512-ZNXLBjkPV6ftLCmmRCafak3XmSn8YV0tKE/ZOhzKys7TZXUiE0mZxlH8zKDo6j6TTUaDnuij68gIG+0Ucm7Xhw==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4"
@@ -1228,17 +1257,17 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "7.3.3",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.3.tgz",
-      "integrity": "sha512-kwNAUh7bLZ7mRz9JZ+6qfRnnxbE4Zuc+RzXnhSpRSxjTlSTj7b4JxRLXpG+MVtPVtqks5k/XC8No1Vs3x4Z2gg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-7.3.5.tgz",
+      "integrity": "sha512-jisvFsEC3sgjUjcPnR4mYfhzjCDIudttSGSbe1o/IXFNu0kZuR+7vqQI0jg8qtcVZBHWrwTfvAZj9MNMumcq1g==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@mui/types": "^7.4.7",
+        "@mui/types": "^7.4.8",
         "@types/prop-types": "^15.7.15",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
-        "react-is": "^19.1.1"
+        "react-is": "^19.2.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -1846,6 +1875,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.0.tgz",
       "integrity": "sha512-1LOH8xovvsKsCBq1wnT4ntDUdCJKmnEakhsuoUSy6ExlHCkGP2hqnatagYTgFk6oeL0VU31u7SNjunPN+GchtA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -1915,6 +1945,7 @@
       "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.45.0",
         "@typescript-eslint/types": "8.45.0",
@@ -2432,6 +2463,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2947,7 +2979,8 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3352,6 +3385,7 @@
       "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3526,6 +3560,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5718,6 +5753,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5727,6 +5763,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6477,6 +6514,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6626,6 +6664,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@mui/icons-material": "^7.3.5",
     "@mui/material": "^7.3.4",
     "@react-oauth/google": "^0.12.2",
     "next": "15.5.4",

--- a/src/app/(withNavbar)/profile/page.tsx
+++ b/src/app/(withNavbar)/profile/page.tsx
@@ -1,44 +1,67 @@
 'use client';
 
 import { useUser } from '@/hooks/useUser';
+import TopMoviesManager from '@/components/TopMoviesManager';
+import { Container, Typography, Box, Paper, Divider } from '@mui/material';
+import Spinner from '@/components/Spinner';
 
 export default function ProfilePage() {
   const { user, isLoading, error } = useUser();
 
   if (isLoading) {
     return (
-      <main style={{ padding: 24 }}>
-        <p>Loading…</p>
-      </main>
+      <Container component="main" maxWidth="md" sx={{ py: 4 }}>
+        <Spinner />
+      </Container>
     );
   }
 
   if (error) {
     return (
-      <main style={{ padding: 24 }}>
-        <h1>My Profile</h1>
-        <p>We couldn't load your profile. Please try again.</p>
-      </main>
+      <Container component="main" maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          My Profile
+        </Typography>
+        <Typography color="error">
+          We couldn&apos;t load your profile. Please try again.
+        </Typography>
+      </Container>
     );
   }
 
   if (!user) {
     return (
-      <main style={{ padding: 24 }}>
-        <h1>My Profile</h1>
-        <p>You're not signed in. <a href="/login">Sign in</a></p>
-      </main>
+      <Container component="main" maxWidth="md" sx={{ py: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          My Profile
+        </Typography>
+        <Typography>
+          You&apos;re not signed in. <a href="/login">Sign in</a>
+        </Typography>
+      </Container>
     );
   }
 
   return (
-    <main style={{ padding: 24, maxWidth: 720, margin: '0 auto' }}>
-      <h1 style={{ fontSize: 24, fontWeight: 700 }}>My Profile</h1>
+    <Container component="main" maxWidth="md" sx={{ py: 4 }}>
+      <Typography variant="h4" component="h1" gutterBottom sx={{ fontWeight: 'bold' }}>
+        My Profile
+      </Typography>
 
-      <section style={{ marginTop: 16 }}>
-        <p><strong>Name:</strong> {user.displayName ?? user.displayName ?? '—'}</p>
-        <p><strong>Bio:</strong> {user.bio ?? '—'}</p>
-      </section>
-    </main>
+      <Paper sx={{ p: 3, mb: 4 }}>
+        <Box sx={{ mb: 2 }}>
+          <Typography variant="body1" sx={{ mb: 1 }}>
+            <strong>Name:</strong> {user.displayName ?? '—'}
+          </Typography>
+          <Typography variant="body1">
+            <strong>Bio:</strong> {user.bio ?? '—'}
+          </Typography>
+        </Box>
+      </Paper>
+
+      <Divider sx={{ mb: 4 }} />
+
+      <TopMoviesManager initialTopMovies={user.topMovies} />
+    </Container>
   );
 }

--- a/src/components/SearchResultsModal.tsx
+++ b/src/components/SearchResultsModal.tsx
@@ -10,7 +10,7 @@ interface SearchResultsModalProps {
 }
 
 const style = {
-  position: 'absolute' as 'absolute',
+  position: 'absolute' as const,
   top: '50%',
   left: '50%',
   transform: 'translate(-50%, -50%)',
@@ -30,7 +30,7 @@ export default function SearchResultsModal({ query, open, onClose }: SearchResul
     <Modal open={open} onClose={onClose}>
       <Box sx={style}>
         <Typography variant="h6" component="h2" gutterBottom>
-          Search Results for "{query}"
+          Search Results for &quot;{query}&quot;
         </Typography>
         {isLoading && <Spinner />}
         {error && <Typography color="error">Failed to load search results.</Typography>}

--- a/src/components/TopMovieCard.tsx
+++ b/src/components/TopMovieCard.tsx
@@ -1,0 +1,143 @@
+import Link from 'next/link';
+import { FavoriteMovie } from '@/types';
+import {
+  Card,
+  CardContent,
+  CardMedia,
+  Typography,
+  Box,
+  Chip,
+  Rating,
+  IconButton
+} from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface TopMovieCardProps {
+  movie: FavoriteMovie;
+  onEdit?: () => void;
+  onRemove?: () => void;
+  isEditable?: boolean;
+}
+
+const rankColors: { [key: number]: string } = {
+  1: '#FFD700', // Gold
+  2: '#C0C0C0', // Silver
+  3: '#CD7F32', // Bronze
+};
+
+export default function TopMovieCard({
+  movie,
+  onEdit,
+  onRemove,
+  isEditable = false
+}: TopMovieCardProps) {
+  const imageUrl = movie.posterURL
+    ? `https://image.tmdb.org/t/p/w500${movie.posterURL}`
+    : '/placeholder.png';
+
+  const cardContent = (
+    <Card
+      sx={{
+        display: 'flex',
+        mb: 3,
+        height: 200,
+        position: 'relative',
+        border: `3px solid ${rankColors[movie.rank]}`,
+        boxShadow: 3,
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 10,
+          left: 10,
+          zIndex: 1,
+        }}
+      >
+        <Chip
+          label={`#${movie.rank}`}
+          sx={{
+            bgcolor: rankColors[movie.rank],
+            color: 'black',
+            fontWeight: 'bold',
+            fontSize: '1.1rem',
+            height: 36,
+            minWidth: 50,
+          }}
+        />
+      </Box>
+
+      <CardMedia
+        component="img"
+        sx={{ width: 140 }}
+        image={imageUrl}
+        alt={movie.title}
+      />
+
+      <Box sx={{ display: 'flex', flexDirection: 'column', flexGrow: 1 }}>
+        <CardContent sx={{ flex: '1 0 auto', pt: 2 }}>
+          <Typography component="div" variant="h6" sx={{ fontWeight: 'bold' }}>
+            {movie.title}
+          </Typography>
+
+          {movie.releaseDate && (
+            <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
+              {new Date(movie.releaseDate).getFullYear()}
+            </Typography>
+          )}
+
+          {movie.voteAverage !== undefined && (
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
+              <Rating value={movie.voteAverage / 2} precision={0.1} readOnly size="small" />
+              <Typography variant="body2" color="text.secondary" sx={{ ml: 1 }}>
+                {movie.voteAverage.toFixed(1)}/10
+              </Typography>
+            </Box>
+          )}
+
+          {movie.overview && (
+            <Typography
+              variant="body2"
+              color="text.secondary"
+              sx={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                display: '-webkit-box',
+                WebkitLineClamp: 2,
+                WebkitBoxOrient: 'vertical',
+              }}
+            >
+              {movie.overview}
+            </Typography>
+          )}
+        </CardContent>
+
+        {isEditable && (
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end', p: 1 }}>
+            {onEdit && (
+              <IconButton size="small" onClick={onEdit} color="primary">
+                <EditIcon />
+              </IconButton>
+            )}
+            {onRemove && (
+              <IconButton size="small" onClick={onRemove} color="error">
+                <DeleteIcon />
+              </IconButton>
+            )}
+          </Box>
+        )}
+      </Box>
+    </Card>
+  );
+
+  if (isEditable) {
+    return cardContent;
+  }
+
+  return (
+    <Link href={`/movie/${movie.movieId}`} passHref style={{ textDecoration: 'none' }}>
+      {cardContent}
+    </Link>
+  );
+}

--- a/src/components/TopMovieSelector.tsx
+++ b/src/components/TopMovieSelector.tsx
@@ -1,0 +1,123 @@
+import { useState } from 'react';
+import { useMovieSearch } from '@/hooks';
+import { Movie } from '@/types';
+import Spinner from './Spinner';
+import {
+  Modal,
+  Box,
+  Typography,
+  TextField,
+  Card,
+  CardContent,
+  CardMedia
+} from '@mui/material';
+
+interface TopMovieSelectorProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectMovie: (movie: Movie) => void;
+  rankPosition: number;
+}
+
+const modalStyle = {
+  position: 'absolute' as const,
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '80%',
+  maxWidth: 600,
+  bgcolor: 'background.paper',
+  boxShadow: 24,
+  p: 4,
+  maxHeight: '90vh',
+  overflowY: 'auto',
+};
+
+export default function TopMovieSelector({
+  open,
+  onClose,
+  onSelectMovie,
+  rankPosition
+}: TopMovieSelectorProps) {
+  const [query, setQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const { movies, isLoading, error } = useMovieSearch(searchQuery);
+
+  const handleSearch = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (query.trim()) {
+      setSearchQuery(query);
+    }
+  };
+
+  const handleSelectMovie = (movie: Movie) => {
+    onSelectMovie(movie);
+    setQuery('');
+    setSearchQuery('');
+    onClose();
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box sx={modalStyle}>
+        <Typography variant="h6" component="h2" gutterBottom>
+          Select Movie for Rank #{rankPosition}
+        </Typography>
+
+        <form onSubmit={handleSearch}>
+          <TextField
+            fullWidth
+            label="Search for a movie..."
+            variant="outlined"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            sx={{ mb: 3 }}
+            autoFocus
+          />
+        </form>
+
+        {isLoading && <Spinner />}
+        {error && <Typography color="error">Failed to load search results.</Typography>}
+
+        {movies && movies.length > 0 ? (
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {movies.map(movie => (
+              <Card
+                key={movie.id}
+                sx={{
+                  display: 'flex',
+                  cursor: 'pointer',
+                  '&:hover': { bgcolor: 'action.hover' }
+                }}
+                onClick={() => handleSelectMovie(movie)}
+              >
+                <CardMedia
+                  component="img"
+                  sx={{ width: 100 }}
+                  image={movie.posterURL ? `https://image.tmdb.org/t/p/w500${movie.posterURL}` : '/placeholder.png'}
+                  alt={movie.title}
+                />
+                <CardContent sx={{ flex: 1 }}>
+                  <Typography variant="h6">{movie.title}</Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                  }}>
+                    {movie.overview}
+                  </Typography>
+                </CardContent>
+              </Card>
+            ))}
+          </Box>
+        ) : (
+          searchQuery && !isLoading && (
+            <Typography>No results found. Try a different search.</Typography>
+          )
+        )}
+      </Box>
+    </Modal>
+  );
+}

--- a/src/components/TopMoviesManager.tsx
+++ b/src/components/TopMoviesManager.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect } from 'react';
+import { FavoriteMovie, Movie, TopMovieInput } from '@/types';
+import { useUserMutations } from '@/hooks';
+import TopMovieCard from './TopMovieCard';
+import TopMovieSelector from './TopMovieSelector';
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  IconButton,
+  Menu,
+  MenuItem
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import SaveIcon from '@mui/icons-material/Save';
+import CancelIcon from '@mui/icons-material/Cancel';
+import SwapVertIcon from '@mui/icons-material/SwapVert';
+import toast from 'react-hot-toast';
+
+interface TopMoviesManagerProps {
+  initialTopMovies?: FavoriteMovie[];
+}
+
+export default function TopMoviesManager({ initialTopMovies = [] }: TopMoviesManagerProps) {
+  const [topMovies, setTopMovies] = useState<FavoriteMovie[]>(initialTopMovies || []);
+  const [isEditing, setIsEditing] = useState(false);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const [selectedRank, setSelectedRank] = useState<number | null>(null);
+  const [rankMenuAnchor, setRankMenuAnchor] = useState<null | HTMLElement>(null);
+  const [movieToChangeRank, setMovieToChangeRank] = useState<FavoriteMovie | null>(null);
+
+  const { updateUserProfile } = useUserMutations();
+
+  useEffect(() => {
+    setTopMovies(initialTopMovies || []);
+  }, [initialTopMovies]);
+
+  const handleAddMovie = (rank: number) => {
+    setSelectedRank(rank);
+    setSelectorOpen(true);
+  };
+
+  const handleSelectMovie = (movie: Movie) => {
+    if (selectedRank === null) return;
+
+    const newMovie: FavoriteMovie = {
+      rank: selectedRank,
+      movieId: movie.id,
+      title: movie.title,
+      posterURL: movie.posterURL,
+      overview: movie.overview,
+    };
+
+    // Remove any existing movie at this rank
+    const filteredMovies = topMovies.filter(m => m.rank !== selectedRank);
+    setTopMovies([...filteredMovies, newMovie].sort((a, b) => a.rank - b.rank));
+  };
+
+  const handleRemoveMovie = (rank: number) => {
+    setTopMovies(topMovies.filter(m => m.rank !== rank));
+  };
+
+  const handleChangeRank = (movie: FavoriteMovie, event: React.MouseEvent<HTMLElement>) => {
+    setMovieToChangeRank(movie);
+    setRankMenuAnchor(event.currentTarget);
+  };
+
+  const handleSelectNewRank = (newRank: number) => {
+    if (!movieToChangeRank) return;
+
+    const existingMovieAtNewRank = topMovies.find(m => m.rank === newRank);
+
+    // Swap ranks if there's a movie at the new rank
+    const updatedMovies = topMovies.map(m => {
+      if (m.rank === movieToChangeRank.rank) {
+        return { ...m, rank: newRank };
+      }
+      if (existingMovieAtNewRank && m.rank === newRank) {
+        return { ...m, rank: movieToChangeRank.rank };
+      }
+      return m;
+    });
+
+    setTopMovies(updatedMovies.sort((a, b) => a.rank - b.rank));
+    setRankMenuAnchor(null);
+    setMovieToChangeRank(null);
+  };
+
+  const handleSave = async () => {
+    const toastId = toast.loading('Saving your top movies...');
+
+    try {
+      const payload: TopMovieInput[] = topMovies.map(m => ({
+        rank: m.rank,
+        movieId: m.movieId,
+      }));
+
+      await updateUserProfile({ topMovies: payload });
+
+      toast.success('Top movies updated successfully!', { id: toastId });
+      setIsEditing(false);
+    } catch (error) {
+      console.error('Failed to update top movies:', error);
+      toast.error('Failed to update top movies. Please try again.', { id: toastId });
+    }
+  };
+
+  const handleCancel = () => {
+    setTopMovies(initialTopMovies || []);
+    setIsEditing(false);
+  };
+
+
+  return (
+    <Box sx={{ mt: 4 }}>
+      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+        <Typography variant="h5" component="h2" sx={{ fontWeight: 'bold' }}>
+          My Top 3 Movies
+        </Typography>
+
+        {!isEditing ? (
+          <Button
+            variant="contained"
+            onClick={() => setIsEditing(true)}
+            startIcon={<AddIcon />}
+          >
+            Edit Top Movies
+          </Button>
+        ) : (
+          <Box sx={{ display: 'flex', gap: 1 }}>
+            <Button
+              variant="contained"
+              color="success"
+              onClick={handleSave}
+              startIcon={<SaveIcon />}
+            >
+              Save
+            </Button>
+            <Button
+              variant="outlined"
+              onClick={handleCancel}
+              startIcon={<CancelIcon />}
+            >
+              Cancel
+            </Button>
+          </Box>
+        )}
+      </Box>
+
+      {(!topMovies || topMovies.length === 0) && !isEditing ? (
+        <Paper sx={{ p: 3, textAlign: 'center', bgcolor: 'background.default' }}>
+          <Typography variant="body1" color="text.secondary">
+            You haven&apos;t selected your top 3 movies yet. Click &quot;Edit Top Movies&quot; to get started!
+          </Typography>
+        </Paper>
+      ) : (
+        <Box>
+          {[1, 2, 3].map(rank => {
+            const movie = topMovies.find(m => m.rank === rank);
+            return (
+              <Box key={rank}>
+                {movie ? (
+                  <Box sx={{ position: 'relative' }}>
+                    <TopMovieCard
+                      movie={movie}
+                      isEditable={isEditing}
+                      onEdit={isEditing ? () => handleAddMovie(rank) : undefined}
+                      onRemove={isEditing ? () => handleRemoveMovie(rank) : undefined}
+                    />
+                    {isEditing && (
+                      <IconButton
+                        sx={{
+                          position: 'absolute',
+                          top: 50,
+                          right: 10,
+                          bgcolor: 'background.paper',
+                          '&:hover': { bgcolor: 'action.hover' }
+                        }}
+                        size="small"
+                        onClick={(e) => handleChangeRank(movie, e)}
+                        title="Change rank"
+                      >
+                        <SwapVertIcon />
+                      </IconButton>
+                    )}
+                  </Box>
+                ) : isEditing ? (
+                  <Paper
+                    sx={{
+                      p: 3,
+                      mb: 3,
+                      textAlign: 'center',
+                      border: '2px dashed',
+                      borderColor: 'divider',
+                      cursor: 'pointer',
+                      '&:hover': { bgcolor: 'action.hover' }
+                    }}
+                    onClick={() => handleAddMovie(rank)}
+                  >
+                    <Typography variant="h6" color="text.secondary">
+                      + Add Movie for Rank #{rank}
+                    </Typography>
+                  </Paper>
+                ) : null}
+              </Box>
+            );
+          })}
+        </Box>
+      )}
+
+      <TopMovieSelector
+        open={selectorOpen}
+        onClose={() => setSelectorOpen(false)}
+        onSelectMovie={handleSelectMovie}
+        rankPosition={selectedRank || 1}
+      />
+
+      <Menu
+        anchorEl={rankMenuAnchor}
+        open={Boolean(rankMenuAnchor)}
+        onClose={() => setRankMenuAnchor(null)}
+      >
+        {[1, 2, 3].map(rank => (
+          <MenuItem
+            key={rank}
+            onClick={() => handleSelectNewRank(rank)}
+            disabled={movieToChangeRank?.rank === rank}
+          >
+            Change to Rank #{rank}
+          </MenuItem>
+        ))}
+      </Menu>
+    </Box>
+  );
+}

--- a/src/types/update-user-payload.interface.ts
+++ b/src/types/update-user-payload.interface.ts
@@ -1,4 +1,10 @@
+export interface TopMovieInput {
+  rank: number; // 1, 2, or 3
+  movieId: number;
+}
+
 export interface UpdateUserPayload {
   displayName?: string;
   bio?: string;
+  topMovies?: TopMovieInput[];
 }

--- a/src/types/user.interface.ts
+++ b/src/types/user.interface.ts
@@ -1,9 +1,20 @@
+export interface FavoriteMovie {
+  rank: number; // 1, 2, or 3
+  movieId: number;
+  title: string;
+  posterURL: string;
+  releaseDate?: string;
+  voteAverage?: number;
+  overview?: string;
+}
+
 export interface User {
   uid: string;
   email: string;
   displayName: string;
   profilePictureUrl: string;
   bio?: string;
+  topMovies?: FavoriteMovie[];
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
This pull request introduces a new "Top 3 Movies" feature to user profiles, allowing users to select, display, and edit their favorite movies. It includes new components for managing and displaying top movies, updates to the user profile page UI for a more modern look, and enhancements to type definitions to support the new feature.

**Top 3 Movies Feature Implementation:**

* Added `TopMoviesManager`, `TopMovieCard`, and `TopMovieSelector` components to allow users to select, display, and edit their top 3 favorite movies directly from their profile. This includes rank management, movie search, and edit/remove capabilities.

**Profile Page UI Enhancements:**

* Refactored the profile page (`page.tsx`) to use Material UI components and integrated the new `TopMoviesManager` component.

**General UI and Code Quality Improvements:**

* Improved modal styling and accessibility in `SearchResultsModal`, and fixed HTML entity rendering.
* Added `@mui/icons-material` dependency to support new icon usage throughout the UI.